### PR TITLE
argo: make CRDs cluster-scoped instead of namespaced

### DIFF
--- a/charts/argo/Chart.yaml
+++ b/charts/argo/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v2.6.1"
 description: A Helm chart for Argo Workflows
 name: argo
-version: 0.7.2
+version: 0.7.3
 icon: https://raw.githubusercontent.com/argoproj/argo/master/docs/assets/argo.png
 home: https://github.com/argoproj/argo-helm
 maintainers:

--- a/charts/argo/crds/cron-workflow-crd.yaml
+++ b/charts/argo/crds/cron-workflow-crd.yaml
@@ -13,5 +13,5 @@ spec:
     shortNames:
     - cronwf
     - cwf
-  scope: Namespaced
+  scope: Cluster
   version: v1alpha1

--- a/charts/argo/crds/workflow-crd.yaml
+++ b/charts/argo/crds/workflow-crd.yaml
@@ -22,5 +22,5 @@ spec:
     plural: workflows
     shortNames:
     - wf
-  scope: Namespaced
+  scope: Cluster
   version: v1alpha1

--- a/charts/argo/crds/workflow-template-crd.yaml
+++ b/charts/argo/crds/workflow-template-crd.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   group: argoproj.io
   version: v1alpha1
-  scope: Namespaced
+  scope: Cluster
   names:
     kind: WorkflowTemplate
     plural: workflowtemplates

--- a/charts/argo/templates/cron-workflow-crd.yaml
+++ b/charts/argo/templates/cron-workflow-crd.yaml
@@ -14,6 +14,6 @@ spec:
     shortNames:
     - cronwf
     - cwf
-  scope: Namespaced
+  scope: Cluster
   version: v1alpha1
 {{- end }}

--- a/charts/argo/templates/workflow-crd.yaml
+++ b/charts/argo/templates/workflow-crd.yaml
@@ -23,6 +23,6 @@ spec:
     plural: workflows
     shortNames:
     - wf
-  scope: Namespaced
+  scope: Cluster
   version: v1alpha1
 {{- end }}

--- a/charts/argo/templates/workflow-template-crd.yaml
+++ b/charts/argo/templates/workflow-template-crd.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   group: argoproj.io
   version: v1alpha1
-  scope: Namespaced
+  scope: Cluster
   names:
     kind: WorkflowTemplate
     plural: workflowtemplates


### PR DESCRIPTION
Checklist:

* [ ] I have update the chart version in `Chart.yaml` following Semantic Versioning.
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have followed the testing instructions in the [contributing guide](https://github.com/argoproj/argo-helm/blob/master/CONTRIBUTING.md).
* [ ] I have signed the CLA and the build is green.
* [ ] I will test my changes again once merged to master and published.

Changes are automatically published when merged to `master`. They are not published on branches.